### PR TITLE
[feat](auth): refreshToken 쿠키 설정 수정

### DIFF
--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -64,8 +64,9 @@ export const signin = async (req, res) => {
     res.cookie("refreshToken", refreshToken, {
       httpOnly: true,
       secure: process.env.NODE_ENV === "production", // HTTPS 환경에서만 전송
-      sameSite: "strict",
-      maxAge: 7 * 24 * 60 * 60 * 1000, // 7일
+      sameSite: "none",                              // **반드시 none**
+      domain: ".interview-town.com",
+      maxAge: 7 * 24 * 60 * 60 * 1000,
     });
 
     return res.status(200).json({
@@ -122,7 +123,8 @@ export const signout = async (req, res) => {
     res.clearCookie("refreshToken", {
       httpOnly: true,
       secure: process.env.NODE_ENV === "production",
-      sameSite: "strict",
+      sameSite: "none",
+      domain: ".interview-town.com",
     });
 
     return res.status(200).json({ message: "로그아웃 성공" });


### PR DESCRIPTION
- sameSite 옵션을 "none"으로 변경하여 크로스 도메인 요청 시 쿠키가 전송되도록 지원
- 도메인(domain) 속성을 ".interview-town.com"으로 지정해 www와 api 서브도메인 간 쿠키 공유 가능
- secure 옵션을 production 환경에서만 활성화하도록 조정